### PR TITLE
Vrindisbacher tracepref wherein

### DIFF
--- a/coq/Langs/S.v
+++ b/coq/Langs/S.v
@@ -2477,7 +2477,7 @@ Proof.
       rewrite Hx in H.
       rewrite (get_rid_of_letstar (a, (Ω', e'))) in H.
       destruct (option_dec ((
-fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
+fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (list event * rtexpr) :=
             let (oΩ, e) := r in
             let* _ := oΩ
             in match fuel with
@@ -2495,9 +2495,8 @@ fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
                end
                 ) fuel (Ω', e'))) as [Hx0|Hy0]; try rewrite Hy0 in H.
       2: inv H.
-      (* apply not_eq_None_Some in Hx0 as [[As0 r1'] Hx0]; 
-(* THIS LINE IS NOW BROKEN *)
-      rewrite Hx0 in H.  
+      apply not_eq_None_Some in Hx0 as [[As0 r1'] Hx0].
+      rewrite Hx0 in H.
       rewrite (get_rid_of_letstar (As0, r1')) in H.
       rewrite <- equiv_estep in Hx;
       destruct a as [a|]; inv H.
@@ -2510,8 +2509,7 @@ fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
         destruct Ω' as [Ω'|]; try now cbn.
         apply (fuel_step Hf) in Hx.
         eapply IHfuel; eauto. 
-Qed. *) 
-Admitted. 
+Qed.
 
 Lemma star_stepf_is_nodupinv_invariant Ω e Ω' e' a fuel :
   Some fuel = get_fuel e ->

--- a/coq/Langs/T.v
+++ b/coq/Langs/T.v
@@ -1802,7 +1802,7 @@ fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
       2: inv H.
       (*
       apply not_eq_None_Some in Hx0 as [[As0 r1'] Hx0]; 
-      (* THIS LINE IS BROKEN *)
+  (* THIS LINE IS NOW BROKEN *)
       rewrite Hx0 in H.
       rewrite (get_rid_of_letstar (As0, r1')) in H.
       rewrite <- equiv_estep in Hx;

--- a/coq/Langs/T.v
+++ b/coq/Langs/T.v
@@ -1614,13 +1614,13 @@ Definition star_stepf (fuel : nat) (r : rtexpr) : option (tracepref * rtexpr) :=
     let* Ω := oΩ in
     match fuel, e with
     | 0, Xres(Fres _) => (* refl *)
-      Some(Tnil, r)
+      Some(nil, r)
     | S fuel', _ => (* trans *)
       let* (a, r') := estepf r in
       let* (As, r'') := doo fuel' r' in
       match a with
       | None => Some(As, r'')
-      | Some(a') => Some(Tcons a' As, r'')
+      | Some(a') => Some(a' :: As, r'')
       end
     | _, _ => None
     end
@@ -1728,7 +1728,7 @@ Lemma star_stepf_one_step Ω e r r' a As fuel :
   Some (S fuel) = get_fuel e ->
   estep (Ω ▷ e) (Some a) r ->
   star_stepf fuel r = Some(As, r') ->
-  star_stepf (S fuel) (Ω ▷ e) = Some(Tcons a As, r')
+  star_stepf (S fuel) (Ω ▷ e) = Some(a :: As, r')
 .
 Proof. Admitted.
 Lemma star_stepf_one_unimportant_step Ω e r r' As fuel :
@@ -1787,20 +1787,23 @@ fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
             let* _ := oΩ
             in match fuel with
                | 0 => match e with
-                      | Xres(Fres _) => Some (Tnil, r)
+                      | Xres(Fres _) => Some (nil, r)
                       | _ => None
                       end
                | S fuel' =>
                    let* (a, r') := estepf r
                    in let* (As, r'') := doo fuel' r'
                       in match a with
-                         | Some a' => Some (Tcons a' As, r'')
+                         | Some a' => Some (a' :: As, r'')
                          | None => Some (As, r'')
                          end
                end
                 ) fuel (Ω', e'))) as [Hx0|Hy0]; try rewrite Hy0 in H.
       2: inv H.
-      apply not_eq_None_Some in Hx0 as [[As0 r1'] Hx0]; rewrite Hx0 in H.
+      (*
+      apply not_eq_None_Some in Hx0 as [[As0 r1'] Hx0]; 
+      (* THIS LINE IS BROKEN *)
+      rewrite Hx0 in H.
       rewrite (get_rid_of_letstar (As0, r1')) in H.
       rewrite <- equiv_estep in Hx;
       destruct a as [a|]; inv H.
@@ -1813,7 +1816,8 @@ fix doo (fuel : nat) (r : rtexpr) {struct fuel} : option (tracepref * rtexpr) :=
         destruct Ω' as [Ω'|]; try now cbn.
         apply (fuel_step Hf) in Hx.
         eapply IHfuel; eauto.
-Qed.
+Qed. *) 
+Admitted. 
 
 Lemma star_stepf_is_nodupinv_invariant Ω e Ω' e' a fuel :
   Some fuel = get_fuel e ->

--- a/coq/Langs/TMMon.v
+++ b/coq/Langs/TMMon.v
@@ -183,10 +183,11 @@ Qed.
 Theorem TMS_refines_tmssafe As :
   TMS As -> simptmssafe As.
 Proof.
-  intros [T__TMS H]; induction H; try apply simptmssafe_nil; try easy.
-  intros ℓ n H2. 
-  apply (@before_split _ _ _ _ (S n)); left. 
-  apply (IHstar_step _ (pred n)) , wherein_predecessor with (b := a); trivial.
+  intros [T__TMS H]; induction H; try easy; try apply simptmssafe_nil; intros ℓ n H2.
+  unfold before.
+
+  (* - eapply before_split; left;  *)
+    (* apply (IHstar_step _ (pred n)) , wherein_predecessor with (b := a); easy. *)
 Admitted.
 
 Module TMMonNotation.

--- a/coq/Langs/TMMon.v
+++ b/coq/Langs/TMMon.v
@@ -177,14 +177,10 @@ Theorem TMS_refines_tmssafe As :
   TMS As -> simptmssafe As.
 Proof.
   intros [T__TMS H]; induction H; try easy; 
-  intros ℓ n H2; apply (@before_split _ _ _ _ n); left;
-  apply (IHstar_step _ (pred n)) , wherein_predecessor with (b := a); trivial.
-  admit.
-  (* inversion H2; try easy.
-  assert (n <> 0). 
-    { rewrite NPeano.Nat.neq_0_lt_0. eapply wherein_n_cons_gt0; eapply H2. } 
-  unfold "<>" in H6; subst; contradiction. *) 
-  Admitted.
+  intros ℓ n H2. 
+  apply (@before_split _ _ _ _ (S n)); left; 
+  apply (IHstar_step _ (pred n)), wherein_predecessor with (b := a); trivial.
+Admitted.
 
 Module TMMonNotation.
 Notation "T1 '⊆__F' T2" := (entails T1 T2) (at level 82, T2 at next level).

--- a/coq/Langs/TMMon.v
+++ b/coq/Langs/TMMon.v
@@ -179,11 +179,12 @@ Proof.
   intros [T__TMS H]; induction H; try easy; 
   intros ℓ n H2; apply (@before_split _ _ _ _ n); left;
   apply (IHstar_step _ (pred n)) , wherein_predecessor with (b := a); trivial.
-  inversion H2; try easy.
+  admit.
+  (* inversion H2; try easy.
   assert (n <> 0). 
-    { rewrite NPeano.Nat.neq_0_lt_0. eapply wherein_n_cons_gt0; eapply H2. }
-  unfold "<>" in H6; subst; contradiction.
-Qed.
+    { rewrite NPeano.Nat.neq_0_lt_0. eapply wherein_n_cons_gt0; eapply H2. } 
+  unfold "<>" in H6; subst; contradiction. *) 
+  Admitted.
 
 Module TMMonNotation.
 Notation "T1 '⊆__F' T2" := (entails T1 T2) (at level 82, T2 at next level).

--- a/coq/Langs/TMMon.v
+++ b/coq/Langs/TMMon.v
@@ -172,14 +172,21 @@ Definition TMS (As : tracepref) :=
 Definition simptmssafe (As : tracepref) :=
   forall ℓ n, wherein (Salloc ℓ) As n -> before (Salloc ℓ) (Sdealloc ℓ) As
 .
+
+Lemma simptmssafe_nil : simptmssafe nil.
+Proof.
+  unfold simptmssafe; intros.
+  apply wherein_nil in H; contradiction.
+Qed.
+
 (* Show the above are equally strong...? *)
 Theorem TMS_refines_tmssafe As :
   TMS As -> simptmssafe As.
 Proof.
-  intros [T__TMS H]; induction H; try easy; 
+  intros [T__TMS H]; induction H; try apply simptmssafe_nil; try easy.
   intros ℓ n H2. 
-  apply (@before_split _ _ _ _ (S n)); left; 
-  apply (IHstar_step _ (pred n)), wherein_predecessor with (b := a); trivial.
+  apply (@before_split _ _ _ _ (S n)); left. 
+  apply (IHstar_step _ (pred n)) , wherein_predecessor with (b := a); trivial.
 Admitted.
 
 Module TMMonNotation.

--- a/coq/Langs/Util.v
+++ b/coq/Langs/Util.v
@@ -719,6 +719,19 @@ Module Mod (X : MOD).
   Proof.
   Admitted.
 
+  Lemma wherein_n_cons_gt0 (a b : Ev) (As : tracepref):  
+    forall n, a <> b -> wherein a (Tcons b As) n -> n > 0.
+  Proof.
+    intros n H1 H2; inv H2; try easy; try apply Gt.gt_Sn_O.
+  Qed. 
+
+  Lemma wherein_predecessor (a b: Ev) (As : tracepref) : 
+    forall n, a <> b -> wherein a (Tcons b As) n -> wherein a As (pred n).
+  Proof.
+    intros n H1 H2; inversion H2; subst; try contradiction.
+    rewrite PeanoNat.Nat.pred_succ; assumption.
+  Qed.
+
   Definition once (a : Ev) (As : tracepref) :=
     forall n m, wherein a As n -> wherein a As m -> n = m
   .

--- a/coq/Langs/Util.v
+++ b/coq/Langs/Util.v
@@ -713,12 +713,28 @@ Module Mod (X : MOD).
   Proof. unfold before; intros H; deex; destruct H as [H0 [H1 H2]]; inv H0. Qed.
 
   Lemma before_split a As a0 a1 n :
-    before a0 a1 As \/ (a0 = a /\ wherein a1 As n) ->
+    (a0 <> a /\ a <> a1 /\ before a0 a1 As) \/ (a0 = a /\ a1 <> a /\ wherein a1 As n) ->
     before a0 a1 (Tcons a As)
   .
   Proof.
-  Admitted.
+    intros H.
+    destruct H as [H | [H1 [H2 H3]]].
+    - destruct H as [H1 H2 H3]; destruct H2 as [H3 H4] , H4 as [x H4] , H4 as [x' H4] , H4 as [H4 [H5 H6]].
+      exists (S x) , (S x'); repeat split; try (apply whereinS; assumption).
+      + apply whereinS; unfold "<>"; intros. apply H3; symmetry; assumption. apply H5.
+      + rewrite <- PeanoNat.Nat.succ_lt_mono; assumption.
+    - subst; exists 0 , (S n); repeat split.
+      + apply whereinZ.
+      + apply whereinS; assumption.
+      + apply PeanoNat.Nat.lt_0_succ.
+  Qed.
 
+  Lemma wherein_nil (a : Ev) :
+    forall n, wherein a Tnil n -> False.
+  Proof.
+    intros n H; inv H.
+  Qed. 
+  
   Lemma wherein_n_cons_gt0 (a b : Ev) (As : tracepref):  
     forall n, a <> b -> wherein a (Tcons b As) n -> n > 0.
   Proof.

--- a/coq/Langs/Util.v
+++ b/coq/Langs/Util.v
@@ -723,12 +723,12 @@ Module Mod (X : MOD).
     forall n, a <> b -> wherein a (Tcons b As) n -> n > 0.
   Proof.
     intros n H1 H2; inv H2; try easy; try apply Gt.gt_Sn_O.
-  Qed. 
+  Qed.
 
   Lemma wherein_predecessor (a b: Ev) (As : tracepref) : 
     forall n, a <> b -> wherein a (Tcons b As) n -> wherein a As (pred n).
   Proof.
-    intros n H1 H2; inversion H2; subst; try contradiction.
+    intros n H1 H2; inv H2; try contradiction.
     rewrite PeanoNat.Nat.pred_succ; assumption.
   Qed.
 

--- a/coq/Langs/Util.v
+++ b/coq/Langs/Util.v
@@ -768,15 +768,14 @@ Module Mod (X : MOD).
     forall n, wherein a As n -> wherein a (b :: As) (n + 1).
   Proof.
     intros n H.
-    apply whereinE in H; apply whereinE.
-    rewrite <- H; apply nth_error_In in H.
-    assert (In a (b :: As)).
-      { rewrite in_cons_variant; right; trivial. }
-    assert (NoDup (b :: As)).
-      { apply tracepref_unique. }
-  Admitted. 
+    apply whereinE in H; apply whereinE; rewrite <- H.
+    destruct n.
+    - reflexivity.
+    - simpl; destruct As.
+      + rewrite PeanoNat.Nat.add_1_r; reflexivity. 
+      + rewrite PeanoNat.Nat.add_1_r; simpl; reflexivity.
+  Qed.
     
-
   Definition before (a0 a1 : Ev) (As : tracepref) : Prop :=
     exists n0 n1, wherein a0 As n0 /\ wherein a1 As n1 /\ n0 < n1
   .


### PR DESCRIPTION
@DasNaCl , can you take a look at why the proofs for `equiv_starstep` in S.v and T.v no longer go through when using list for tracepref. The problem is this line: `rewrite Hx0 in H.`, just under a comment that says `(* THIS IS NOW BROKEN *)`. 

Also, please take a look at the axiom used for TMMon.v. Not sure if we want what is currently there, or `TMS As -> ...`. The proof will require some fiddling if we want the latter.